### PR TITLE
Ability to request extra fields when using collection utility

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -53,7 +53,8 @@ var collection = rdioUtils.collectionAlbums({
   onRemoved: function(albums) {
     // Called after the initial load when the user removes albums from their 
     // collection.
-  }
+  },
+  extraAlbumFields: "playCount" // Additional fields for the `extras` parameter
 });
 ```
 


### PR DESCRIPTION
Previously the initial load would retrieve CollectionAlbum objects and
when processing "add to collection" events, it would retrieve
Album objects. This causes an issue if you're requesting
CollectionAlbum-specific fields (i.e. itemTrackKeys).

Now calls to the `get` API method use the CollectionAlbum key instead.
This is done by adding a `collectionKey` to the stored album object.

cc @iangilman 
